### PR TITLE
fix: camera_web dependency override to remove audio permission

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -100,11 +100,11 @@ packages:
     source: hosted
     version: "2.2.0"
   camera_web:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: camera_web
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../webCameraPlugin/camera/packages/camera/camera_web"
+      relative: true
+    source: path
     version: "0.3.0"
   characters:
     dependency: transitive
@@ -412,7 +412,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -655,7 +655,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -697,21 +697,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.18"
   typed_data:
     dependency: transitive
     description:
@@ -788,7 +788,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   very_good_analysis:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,10 @@ dependencies:
   rxdart: ^0.26.0
   uuid: ^3.0.6
 
+dependency_overrides:
+  camera_web:
+    path: '../webCameraPlugin/camera/packages/camera/camera_web'
+
 dev_dependencies:
   bloc_test: ^9.1.0
   camera_platform_interface: ^2.2.0


### PR DESCRIPTION
## Description

Added my local version of the Flutter camera_web dependency to dependency overrides in pubspec.yaml
Set EnableAudio to false in camera_web

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
