### PR TITLE
refactor: remove importing dart:html in main project

### DIFF
--- a/packages/tensorflow_models/tensorflow_models/example/lib/src/pages/landmarks_detect_blink_page.dart
+++ b/packages/tensorflow_models/tensorflow_models/example/lib/src/pages/landmarks_detect_blink_page.dart
@@ -1,7 +1,3 @@
-// TODO(alestiago): Use a plugin instead.
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html;
-
 import 'package:camera/camera.dart';
 import 'package:example/src/src.dart';
 import 'package:face_geometry/face_geometry.dart';
@@ -28,16 +24,9 @@ class _LandmarksDetectBlinkView extends StatefulWidget {
 
 class _LandmarksDetectBlinkViewState extends State<_LandmarksDetectBlinkView> {
   CameraController? _cameraController;
-  html.VideoElement? _videoElement;
 
   void _onCameraReady(CameraController cameraController) {
     setState(() => _cameraController = cameraController);
-    WidgetsBinding.instance.addPostFrameCallback((_) => _queryVideoElement());
-  }
-
-  void _queryVideoElement() {
-    final videoElement = html.querySelector('video')! as html.VideoElement;
-    setState(() => _videoElement = videoElement);
   }
 
   @override
@@ -48,16 +37,17 @@ class _LandmarksDetectBlinkViewState extends State<_LandmarksDetectBlinkView> {
         child: Stack(
           children: [
             CameraView(onCameraReady: _onCameraReady),
-            if (_videoElement != null)
+            if (_cameraController != null)
               LayoutBuilder(
                 builder: (context, constraints) {
                   final size = constraints.biggest;
-                  _videoElement!
+                  // ignore: avoid_dynamic_calls
+                  _cameraController!.videoElement
                     ..width = size.width.floor()
                     ..height = size.height.floor();
 
                   return FacesDetectorBuilder(
-                    videoElement: _videoElement!,
+                    cameraController: _cameraController!,
                     builder: (context, faces) {
                       if (faces.isEmpty) return const SizedBox.shrink();
 

--- a/packages/tensorflow_models/tensorflow_models/example/lib/src/pages/landmarks_gif_page.dart
+++ b/packages/tensorflow_models/tensorflow_models/example/lib/src/pages/landmarks_gif_page.dart
@@ -1,8 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-// TODO(alestiago): Use a plugin instead.
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html;
 import 'dart:ui';
 
 import 'package:camera/camera.dart';
@@ -32,7 +29,6 @@ class _LandmarksGifView extends StatefulWidget {
 
 class _LandmarksGifViewState extends State<_LandmarksGifView> {
   CameraController? _cameraController;
-  html.VideoElement? _videoElement;
   final _imagesBytes = <Uint8List>[];
   bool _gifInProgress = false;
 
@@ -40,12 +36,6 @@ class _LandmarksGifViewState extends State<_LandmarksGifView> {
 
   void _onCameraReady(CameraController cameraController) {
     setState(() => _cameraController = cameraController);
-    WidgetsBinding.instance.addPostFrameCallback((_) => _queryVideoElement());
-  }
-
-  void _queryVideoElement() {
-    final videoElement = html.querySelector('video')! as html.VideoElement;
-    setState(() => _videoElement = videoElement);
   }
 
   Future<void> _onTakePhoto() async {
@@ -135,16 +125,17 @@ class _LandmarksGifViewState extends State<_LandmarksGifView> {
             child: Stack(
               children: [
                 CameraView(onCameraReady: _onCameraReady),
-                if (_videoElement != null)
+                if (_cameraController != null)
                   LayoutBuilder(
                     builder: (context, constraints) {
                       final size = constraints.biggest;
-                      _videoElement!
+                      // ignore: avoid_dynamic_calls
+                      _cameraController!.videoElement
                         ..width = size.width.floor()
                         ..height = size.height.floor();
 
                       return FacesDetectorBuilder(
-                        videoElement: _videoElement!,
+                        cameraController: _cameraController!,
                         builder: (context, faces) {
                           if (faces.isEmpty) return const SizedBox.shrink();
 

--- a/packages/tensorflow_models/tensorflow_models/example/lib/src/pages/landmarks_mask_blink_page.dart
+++ b/packages/tensorflow_models/tensorflow_models/example/lib/src/pages/landmarks_mask_blink_page.dart
@@ -1,5 +1,3 @@
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html;
 import 'dart:math';
 
 import 'package:camera/camera.dart';
@@ -30,17 +28,10 @@ class _LandmarksMaskBlinkView extends StatefulWidget {
 
 class _LandmarksMaskBlinkViewState extends State<_LandmarksMaskBlinkView> {
   CameraController? _cameraController;
-  html.VideoElement? _videoElement;
   Point? facePosition;
 
   void _onCameraReady(CameraController cameraController) {
     setState(() => _cameraController = cameraController);
-    WidgetsBinding.instance.addPostFrameCallback((_) => _queryVideoElement());
-  }
-
-  void _queryVideoElement() {
-    final videoElement = html.querySelector('video')! as html.VideoElement;
-    setState(() => _videoElement = videoElement);
   }
 
   @override
@@ -51,17 +42,17 @@ class _LandmarksMaskBlinkViewState extends State<_LandmarksMaskBlinkView> {
         child: Stack(
           children: [
             CameraView(onCameraReady: _onCameraReady),
-            if (_videoElement != null)
+            if (_cameraController != null)
               LayoutBuilder(
                 builder: (context, constraints) {
                   final size = constraints.biggest;
-
-                  _videoElement!
+                  // ignore: avoid_dynamic_calls
+                  _cameraController!.videoElement
                     ..width = size.width.floor()
                     ..height = size.height.floor();
 
                   return FacesDetectorBuilder(
-                    videoElement: _videoElement!,
+                    cameraController: _cameraController!,
                     builder: (context, faces) {
                       if (faces.isEmpty) {
                         return const SizedBox.shrink();

--- a/packages/tensorflow_models/tensorflow_models/example/lib/src/pages/landmarks_open_mouth_page.dart
+++ b/packages/tensorflow_models/tensorflow_models/example/lib/src/pages/landmarks_open_mouth_page.dart
@@ -1,7 +1,3 @@
-// TODO(alestiago): Use a plugin instead.
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html;
-
 import 'package:camera/camera.dart';
 import 'package:example/src/widgets/widgets.dart';
 import 'package:face_geometry/face_geometry.dart';
@@ -29,18 +25,11 @@ class _LandmarksOpenMouthPage extends StatefulWidget {
 
 class _LandmarksOpenMouthPageState extends State<_LandmarksOpenMouthPage> {
   CameraController? _cameraController;
-  html.VideoElement? _videoElement;
 
   late final AudioPlayer _audioPlayer;
 
   void _onCameraReady(CameraController cameraController) {
     setState(() => _cameraController = cameraController);
-    WidgetsBinding.instance.addPostFrameCallback((_) => _queryVideoElement());
-  }
-
-  void _queryVideoElement() {
-    final videoElement = html.querySelector('video')! as html.VideoElement;
-    setState(() => _videoElement = videoElement);
   }
 
   @override
@@ -71,16 +60,17 @@ class _LandmarksOpenMouthPageState extends State<_LandmarksOpenMouthPage> {
         child: Stack(
           children: [
             CameraView(onCameraReady: _onCameraReady),
-            if (_videoElement != null)
+            if (_cameraController != null)
               LayoutBuilder(
                 builder: (context, constraints) {
                   final size = constraints.biggest;
-                  _videoElement!
+                  // ignore: avoid_dynamic_calls
+                  _cameraController!.videoElement
                     ..width = size.width.floor()
                     ..height = size.height.floor();
 
                   return FacesDetectorBuilder(
-                    videoElement: _videoElement!,
+                    cameraController: _cameraController!,
                     builder: (context, faces) {
                       if (faces.isEmpty) return const SizedBox.shrink();
                       if (faces.first.mouthDistance > 15) {

--- a/packages/tensorflow_models/tensorflow_models/example/lib/src/pages/landmarks_video_stream_page.dart
+++ b/packages/tensorflow_models/tensorflow_models/example/lib/src/pages/landmarks_video_stream_page.dart
@@ -1,7 +1,3 @@
-// TODO(alestiago): Use a plugin instead.
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html;
-
 import 'package:camera/camera.dart';
 import 'package:example/src/src.dart';
 import 'package:flutter/material.dart';
@@ -27,16 +23,9 @@ class _LandmarksVideoStreamView extends StatefulWidget {
 
 class _LandmarksVideoStreamViewState extends State<_LandmarksVideoStreamView> {
   CameraController? _cameraController;
-  html.VideoElement? _videoElement;
 
   void _onCameraReady(CameraController cameraController) {
     setState(() => _cameraController = cameraController);
-    WidgetsBinding.instance.addPostFrameCallback((_) => _queryVideoElement());
-  }
-
-  void _queryVideoElement() {
-    final videoElement = html.querySelector('video')! as html.VideoElement;
-    setState(() => _videoElement = videoElement);
   }
 
   @override
@@ -47,16 +36,17 @@ class _LandmarksVideoStreamViewState extends State<_LandmarksVideoStreamView> {
         child: Stack(
           children: [
             Center(child: CameraView(onCameraReady: _onCameraReady)),
-            if (_videoElement != null)
+            if (_cameraController != null)
               LayoutBuilder(
                 builder: (context, constraints) {
                   final size = constraints.biggest;
-                  _videoElement!
+                  // ignore: avoid_dynamic_calls
+                  _cameraController!.videoElement
                     ..width = size.width.floor()
                     ..height = size.height.floor();
 
                   return FacesDetectorBuilder(
-                    videoElement: _videoElement!,
+                    cameraController: _cameraController!,
                     builder: (context, faces) {
                       if (faces.isEmpty) return const SizedBox.shrink();
 

--- a/packages/tensorflow_models/tensorflow_models/example/lib/src/widgets/faces_detector_builder.dart
+++ b/packages/tensorflow_models/tensorflow_models/example/lib/src/widgets/faces_detector_builder.dart
@@ -1,19 +1,17 @@
 import 'dart:async';
-// TODO(alestiago): Use a plugin instead.
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html;
 
+import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:tensorflow_models/tensorflow_models.dart' as tf;
 
 class FacesDetectorBuilder extends StatefulWidget {
   const FacesDetectorBuilder({
     Key? key,
-    required this.videoElement,
+    required this.cameraController,
     required this.builder,
   }) : super(key: key);
 
-  final html.VideoElement videoElement;
+  final CameraController cameraController;
 
   final Widget Function(BuildContext context, tf.Faces faces) builder;
 
@@ -41,7 +39,7 @@ class _FacesDetectorBuilderState extends State<FacesDetectorBuilder> {
 
   Future<bool> _estimateFaces() async {
     final faces = await _faceLandmarksDetector.estimateFaces(
-      widget.videoElement,
+      widget.cameraController.videoElement,
       estimationConfig: _estimationConfig,
     );
     if (!_streamController.isClosed) _streamController.add(faces);

--- a/packages/tensorflow_models/tensorflow_models/example/pubspec.yaml
+++ b/packages/tensorflow_models/tensorflow_models/example/pubspec.yaml
@@ -27,6 +27,13 @@ dev_dependencies:
   flutter_gen_runner:
   very_good_analysis: ^3.1.0
 
+dependency_overrides:
+  camera:
+    git:
+      url: https://github.com/VGVentures/plugins
+      path: packages/camera/camera
+      ref: 824086aa4cd135b72e7ac353d74c2c70b26ec61a
+
 flutter_gen:
   output: lib/assets/
   line_length: 80

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,7 +105,7 @@ packages:
       name: camera_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.0+1"
   characters:
     dependency: transitive
     description:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The aim of this PR is to remove imports of `dart:html` directly from our Photbooth application.

**Evaluated solutions:**
- Implement the `startImageFrame` from the camera plugin which is currently not supported for web
- Implement a dependency override for `camera_web` and `camera` to implement a method to get the `VideoElement` associated to a `CameraController`
- Implement a package with conditional imports that fetches the `VideoElement` when running on web

**Rationale:**
The first possible solution is currently worked on but we envision that the face detection will suffer a significant performance hit due to the amount of copies that need to be done. 

The second solution is preferred over the third solution see #107 .

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
