### PR TITLE
fix: intro text scrolling on mobile

### DIFF
--- a/lib/animoji_intro/widgets/animoji_intro_body.dart
+++ b/lib/animoji_intro/widgets/animoji_intro_body.dart
@@ -104,7 +104,7 @@ class _BottomContent extends StatelessWidget {
             ),
           ),
           Flexible(
-            flex: smallScreen ? 1 : 3,
+            flex: smallScreen ? 0 : 3,
             child: SelectableText(
               l10n.animojiIntroPageSubheading,
               key: const Key('animojiIntro_subheading_text'),
@@ -114,6 +114,7 @@ class _BottomContent extends StatelessWidget {
               textAlign: smallScreen ? TextAlign.center : TextAlign.left,
             ),
           ),
+          if (smallScreen) const SizedBox(height: 16),
           Flexible(
             child: NextButton(
               onNextPressed: () {


### PR DESCRIPTION

## Description
Fixes the intro text scrolling on mobile by making it size itself, rather than getting the size from the flex container.

<img width="361" alt="Screenshot 2023-01-05 at 2 22 39 PM" src="https://user-images.githubusercontent.com/18384371/210863413-6b80a6df-d42c-420f-929b-1638fb328619.png">


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
