### PR TITLE
fix: catch errors playing sounds

### DIFF
--- a/lib/audio_player/audio_player_mixin.dart
+++ b/lib/audio_player/audio_player_mixin.dart
@@ -35,11 +35,17 @@ mixin AudioPlayerMixin<T extends StatefulWidget> on State<T> {
       await _audioPlayer.setLoopMode(LoopMode.all);
     }
 
-    // Restarts the audio track.
-    await _audioPlayer.pause();
-    await _audioPlayer.seek(Duration.zero);
-    await _audioPlayer.play();
-    completer.complete();
+    try {
+      // Restarts the audio track.
+      await _audioPlayer.pause();
+      await _audioPlayer.seek(Duration.zero);
+      await _audioPlayer.play();
+    } catch (_) {
+      // If an error occurs, stop the audio.
+      await _audioPlayer.stop();
+    } finally {
+      completer.complete();
+    }
   }
 
   Future<void> stopAudio() async {
@@ -50,5 +56,25 @@ mixin AudioPlayerMixin<T extends StatefulWidget> on State<T> {
   void dispose() {
     _playing.then((_) => _audioPlayer.dispose());
     super.dispose();
+  }
+}
+
+@visibleForTesting
+class TestWidgetWithAudioPlayer extends StatefulWidget {
+  const TestWidgetWithAudioPlayer({super.key});
+
+  @override
+  State<StatefulWidget> createState() => TestStateWithAudioPlayer();
+}
+
+@visibleForTesting
+class TestStateWithAudioPlayer extends State<TestWidgetWithAudioPlayer>
+    with AudioPlayerMixin {
+  @override
+  String get audioAssetPath => 'audioAssetPath';
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
   }
 }

--- a/lib/in_experience_selection/widgets/recording_button.dart
+++ b/lib/in_experience_selection/widgets/recording_button.dart
@@ -1,17 +1,37 @@
 import 'package:flutter/material.dart';
+import 'package:holobooth/assets/assets.dart';
+import 'package:holobooth/audio_player/audio_player.dart';
 import 'package:holobooth/l10n/l10n.dart';
 import 'package:holobooth_ui/holobooth_ui.dart';
 
-class RecordingButton extends StatelessWidget {
+class RecordingButton extends StatefulWidget {
   const RecordingButton({super.key, required this.onRecordingPressed});
 
   final VoidCallback onRecordingPressed;
 
   @override
+  State<RecordingButton> createState() => _RecordingButtonState();
+}
+
+class _RecordingButtonState extends State<RecordingButton>
+    with AudioPlayerMixin {
+  @override
+  String get audioAssetPath => Assets.audio.counting3Seconds;
+
+  @override
+  void initState() {
+    super.initState();
+    loadAudio();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
     return GradientElevatedButton(
-      onPressed: onRecordingPressed,
+      onPressed: () {
+        playAudio();
+        widget.onRecordingPressed();
+      },
       child: Text(l10n.recordButtonText),
     );
   }

--- a/lib/photo_booth/widgets/get_ready_layer.dart
+++ b/lib/photo_booth/widgets/get_ready_layer.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:holobooth/assets/assets.dart';
-import 'package:holobooth/audio_player/audio_player.dart';
 import 'package:holobooth/l10n/l10n.dart';
 import 'package:holobooth_ui/holobooth_ui.dart';
 
@@ -16,24 +14,24 @@ class GetReadyLayer extends StatefulWidget {
 
   static const countdownDuration = Duration(seconds: 3);
 
-  @visibleForTesting
-  static const emptySizedBox = Key('empty_sizedBox');
-
   @override
   State<GetReadyLayer> createState() => _GetReadyLayerState();
 }
 
 class _GetReadyLayerState extends State<GetReadyLayer>
-    with TickerProviderStateMixin, AudioPlayerMixin {
+    with TickerProviderStateMixin {
   late final AnimationController controller;
-
-  @override
-  String get audioAssetPath => Assets.audio.counting3Seconds;
 
   @override
   void initState() {
     super.initState();
-    _init();
+
+    controller = AnimationController(
+      vsync: this,
+      duration: GetReadyLayer.countdownDuration,
+    )..addStatusListener(_onAnimationStatusChanged);
+
+    controller.reverse(from: 1);
   }
 
   Future<void> _onAnimationStatusChanged(AnimationStatus status) async {
@@ -42,30 +40,11 @@ class _GetReadyLayerState extends State<GetReadyLayer>
     }
   }
 
-  Future<void> _init() async {
-    controller = AnimationController(
-      vsync: this,
-      duration: GetReadyLayer.countdownDuration,
-    )..addStatusListener(_onAnimationStatusChanged);
-
-    try {
-      await loadAudio();
-      unawaited(playAudio());
-    } catch (_) {}
-
-    await controller.reverse(from: 1);
-  }
-
   @override
   Widget build(BuildContext context) {
     return AnimatedBuilder(
       animation: controller,
-      builder: (context, child) {
-        if (controller.isAnimating) {
-          return GetReadyCountdown(controller: controller);
-        }
-        return const SizedBox(key: GetReadyLayer.emptySizedBox);
-      },
+      builder: (context, child) => GetReadyCountdown(controller: controller),
     );
   }
 

--- a/test/photo_booth/widgets/get_ready_layer_test.dart
+++ b/test/photo_booth/widgets/get_ready_layer_test.dart
@@ -1,71 +1,28 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:holobooth/audio_player/audio_player.dart';
 import 'package:holobooth/photo_booth/photo_booth.dart';
-import 'package:just_audio/just_audio.dart';
-import 'package:mocktail/mocktail.dart';
 
 import '../../helpers/helpers.dart';
 
-class _MockAudioPlayer extends Mock implements AudioPlayer {}
-
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-  late AudioPlayer audioPlayer;
-
-  setUp(() {
-    audioPlayer = _MockAudioPlayer();
-    when(() => audioPlayer.setAsset(any())).thenAnswer((_) async => null);
-    when(() => audioPlayer.load()).thenAnswer((_) async {
-      return null;
-    });
-    when(() => audioPlayer.play()).thenAnswer((_) async {});
-    when(() => audioPlayer.pause()).thenAnswer((_) async {});
-    when(() => audioPlayer.stop()).thenAnswer((_) async {});
-    when(() => audioPlayer.seek(any())).thenAnswer((_) async {});
-    when(() => audioPlayer.dispose()).thenAnswer((_) async {});
-    when(() => audioPlayer.playerStateStream).thenAnswer(
-      (_) => Stream.fromIterable(
-        [
-          PlayerState(true, ProcessingState.ready),
-        ],
-      ),
-    );
-
-    AudioPlayerMixin.audioPlayerOverride = audioPlayer;
-
-    const MethodChannel('com.ryanheise.audio_session')
-        .setMockMethodCallHandler((call) async {
-      if (call.method == 'getConfiguration') {
-        return {};
-      }
-    });
-  });
-
-  tearDown(() {
-    AudioPlayerMixin.audioPlayerOverride = null;
-  });
-
   group('GetReadyLayer', () {
-    testWidgets(
-      'set asset correctly',
-      (WidgetTester tester) async {
-        await tester.pumpApp(
-          GetReadyLayer(
-            onCountdownCompleted: () {},
-          ),
-        );
-        await tester.pumpAndSettle();
-        verify(() => audioPlayer.setAsset(any())).called(1);
-        verify(() => audioPlayer.play()).called(1);
-      },
-    );
-
-    testWidgets(
-        'renders GetReadyLayer.emptySizedBox when animation has not started',
-        (tester) async {
+    testWidgets('renders GetReadyCountdown', (tester) async {
       await tester.pumpApp(GetReadyLayer(onCountdownCompleted: () {}));
-      expect(find.byKey(GetReadyLayer.emptySizedBox), findsOneWidget);
+      expect(find.byType(GetReadyCountdown), findsOneWidget);
+    });
+
+    testWidgets('calls onCountdownCompleted after animation completes',
+        (tester) async {
+      var onCountdownCompletedCalled = false;
+      await tester.pumpApp(
+        GetReadyLayer(
+          onCountdownCompleted: () {
+            onCountdownCompletedCalled = true;
+          },
+        ),
+      );
+      expect(onCountdownCompletedCalled, isFalse);
+      await tester.pumpAndSettle();
+      expect(onCountdownCompletedCalled, isTrue);
     });
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
This PR fixes the freezing that was happening when playing sounds on iOS, by catching the error and allowing the audio player to still dispose properly.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
