### PR TITLE
fix: landing page offset

### DIFF
--- a/lib/landing/widgets/landing_body.dart
+++ b/lib/landing/widgets/landing_body.dart
@@ -46,8 +46,11 @@ class _SmallLandingBody extends StatelessWidget {
             children: [
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Assets.backgrounds.holobooth.image(
-                  key: LandingBody.landingPageImageKey,
+                child: Transform.translate(
+                  offset: const Offset(0, 10),
+                  child: Assets.backgrounds.holobooth.image(
+                    key: LandingBody.landingPageImageKey,
+                  ),
                 ),
               ),
               FullFooter(
@@ -76,10 +79,13 @@ class _LargeLandingBody extends StatelessWidget {
             child: Row(
               children: [
                 Expanded(
-                  child: Container(
-                    alignment: Alignment.bottomCenter,
-                    child: Assets.backgrounds.holobooth.image(
-                      key: LandingBody.landingPageImageKey,
+                  child: Transform.translate(
+                    offset: const Offset(0, 10),
+                    child: Container(
+                      alignment: Alignment.bottomCenter,
+                      child: Assets.backgrounds.holobooth.image(
+                        key: LandingBody.landingPageImageKey,
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Description

Small fix to better position the holobooth image on the landing page
Desktop, before
![Screenshot 2023-01-24 at 09 51 47](https://user-images.githubusercontent.com/835641/214296981-f9b18b08-bb8e-4153-bc0d-5c9bfcf11b98.png)
Desktop, after
![Screenshot 2023-01-24 at 09 52 22](https://user-images.githubusercontent.com/835641/214297004-285b48c4-e79a-41bd-a2fe-9cb0ce9ca5ad.png)


Mobile, before
![Screenshot 2023-01-24 at 09 52 57](https://user-images.githubusercontent.com/835641/214297082-eeda41f1-83d3-421b-8220-4e71be3f3683.png)
Mobile, after
![Screenshot 2023-01-24 at 09 53 28](https://user-images.githubusercontent.com/835641/214297093-229ec08d-cc48-4018-a293-973a478037e2.png)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
